### PR TITLE
refactor: 重构TabView和ContextMenu的部分逻辑

### DIFF
--- a/src/components/menu/Contextmenu.vue
+++ b/src/components/menu/Contextmenu.vue
@@ -1,7 +1,14 @@
 <template>
-  <a-menu :style="style" class="contextmenu" v-show="visible" @click="handleClick" :selectedKeys="selectedKeys">
+  <a-menu
+    v-show="visible"
+    class="contextmenu"
+    :style="style"
+    :selectedKeys="selectedKeys"
+    @click="handleClick"
+  >
     <a-menu-item :key="item.key" v-for="item in itemList">
-      <a-icon role="menuitemicon" v-if="item.icon" :type="item.icon" />{{item.text}}
+      <a-icon v-if="item.icon" :type="item.icon" />
+      <span>{{ item.text }}</span>
     </a-menu-item>
   </a-menu>
 </template>
@@ -38,23 +45,27 @@ export default {
     }
   },
   created () {
-    window.addEventListener('mousedown', e => this.closeMenu(e))
-    window.addEventListener('contextmenu', e => this.setPosition(e))
+    const clickHandler = () => this.closeMenu()
+    const contextMenuHandler = e => this.setPosition(e)
+    window.addEventListener('click', clickHandler)
+    window.addEventListener('contextmenu', contextMenuHandler)
+    this.$emit('hook:beforeDestroy', () => {
+      window.removeEventListener('click', clickHandler)
+      window.removeEventListener('contextmenu', contextMenuHandler)
+    })
   },
   methods: {
-    closeMenu (e) {
-      if (['menuitemicon', 'menuitem'].indexOf(e.target.getAttribute('role')) < 0) {
-        this.$emit('update:visible', false)
-      }
+    closeMenu () {
+      this.$emit('update:visible', false)
     },
     setPosition (e) {
       this.left = e.clientX
       this.top = e.clientY
       this.target = e.target
     },
-    handleClick ({key}) {
+    handleClick ({ key }) {
       this.$emit('select', key, this.target)
-      this.$emit('update:visible', false)
+      this.closeMenu()
     }
   }
 }
@@ -63,9 +74,11 @@ export default {
 <style lang="less" scoped>
   .contextmenu{
     position: fixed;
-    z-index: 1;
-
+    z-index: 1000;
     border-radius: 4px;
     box-shadow: -4px 4px 16px 1px @shadow-color !important;
+  }
+  .ant-menu-item {
+    margin: 0 !important // 菜单项之间的缝隙会影响点击
   }
 </style>


### PR DESCRIPTION
1. 提取并修改getPageKey函数，表意更明确
2. 修复ContextMenu点击失败的bug（菜单项之间有margin缝隙）
3. 其他个别代码格式（基于eslint）调整