### PR TITLE
修复路由重定向

### DIFF
--- a/src/utils/routerUtil.js
+++ b/src/utils/routerUtil.js
@@ -35,6 +35,11 @@ function parseRoutes(routesConfig, routerMap) {
           page: routeCfg.page || router.page
         }
       }
+      const redirect = routeCfg.redirect || router.redirect
+      // redirect && route.redirect=redirect
+      if (redirect){
+          route.redirect=redirect
+      }
       if (routeCfg.invisible || router.invisible) {
         route.meta.invisible = true
       }


### PR DESCRIPTION
如果routeCfg和router都未定义的情况下，路由的redirect会默认为undefined