### PR TITLE
修复一个路由解析时候丢失 meta 值的问题

### DIFF
--- a/src/utils/routerUtil.js
+++ b/src/utils/routerUtil.js
@@ -50,10 +50,10 @@ function parseRoutes(routesConfig, routerMap) {
       component: router.component,
       redirect: routeCfg.redirect || router.redirect,
       meta: {
-        authority: routeCfg.authority || router.authority || '*',
-        icon: routeCfg.icon || router.icon,
-        page: routeCfg.page || router.page,
-        link: routeCfg.link || router.link
+        authority: routeCfg.authority || router.authority || routeCfg.meta?.authority || router.meta?.authority || '*',
+        icon: routeCfg.icon || router.icon ||  routeCfg.meta?.icon || router.meta?.icon,
+        page: routeCfg.page || router.page ||  routeCfg.meta?.page || router.meta?.page,
+        link: routeCfg.link || router.link ||  routeCfg.meta?.link || router.meta?.link
       }
     }
     if (routeCfg.invisible || router.invisible) {


### PR DESCRIPTION
感谢您的项目！

在使用异步路由的时候，发现菜单的图标不见了，进一步排查发现是这里合并 routerCfg 和 router 的时候没有将 .meta 里的内容顺利合并（比如根据其它地方的代码以及文档，icon 字段是在 router.meta.icon 下而不是在 router.icon 下），导致最后生成的路由 meta 里面的 icon 等字段变成 undefined 了，此 PR 可以解决这个问题，同时不妨碍您在解析、生成路由时的其它逻辑