### PR TITLE
fix:修复动态路由下cacheAble不生效的问题

### DIFF
--- a/src/layouts/tabs/TabsView.vue
+++ b/src/layouts/tabs/TabsView.vue
@@ -301,7 +301,8 @@ export default {
       routes.forEach(item => {
         const cacheAble = item.meta?.page?.cacheAble ?? pCache ?? true
         if (!cacheAble) {
-          this.excludeKeys.push(new RegExp(`${item.path}\\d+$`))
+          const path = item.path.replace(/:.+?\//g, '.+?/').replace(/:.+?$/g, '.+$')
+          this.excludeKeys.push(new RegExp(`${path}`))
         }
         if (item.children) {
           this.loadCacheConfig(item.children, cacheAble)


### PR DESCRIPTION
/:companyId/:userId
有时候路由会长这个样子，并不需要缓存，cacheAble不会生效，增加了这种情况下的判断。